### PR TITLE
Preserve signature Ai page state during navigation

### DIFF
--- a/src/pages/SignatureAI.tsx
+++ b/src/pages/SignatureAI.tsx
@@ -230,6 +230,22 @@ const SignatureAI = () => {
     saveSessionState();
   }, [selectedStudent, genuineFiles, forgedFiles, currentTrainingSet, visibleCounts]);
 
+  // Ensure state is persisted on internal navigation or tab hide
+  React.useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        // Best-effort save before the page is backgrounded or navigating away
+        saveSessionState();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      // Save once more on unmount to capture any last-moment changes
+      saveSessionState();
+    };
+  }, [selectedStudent, genuineFiles, forgedFiles, currentTrainingSet, visibleCounts]);
+
   React.useEffect(() => {
     setIsStudentSearching(true);
     const t = setTimeout(() => {


### PR DESCRIPTION
Persist Signature AI page state to `sessionStorage` on unmount and visibility change to preserve state during internal navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-ace4b9a9-4536-44f0-8402-0646d854db7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ace4b9a9-4536-44f0-8402-0646d854db7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

