### PR TITLE
Change page title to SESSIONS and simplify sidebar active item styling

### DIFF
--- a/src/components/ui/navigation.tsx
+++ b/src/components/ui/navigation.tsx
@@ -340,7 +340,7 @@ const DesktopNavigation = () => {
                   // Unified dimensions in both states to prevent distortion
                   "h-8 justify-start px-2 w-full rounded-sm overflow-hidden",
                   isActive 
-                    ? "bg-gradient-primary shadow-glow text-white"
+                    ? "bg-blue-100 text-blue-700"
                     : "hover:bg-sidebar-accent/50 hover:text-foreground"
                 )}
               >
@@ -553,7 +553,7 @@ const MobileDrawer = ({ isOpen, onClose }: { isOpen: boolean; onClose: () => voi
                   className={cn(
                     "w-full justify-start gap-3 h-10 text-sm transition-all duration-200 group relative overflow-hidden",
                     isActive 
-                      ? "bg-gradient-primary shadow-glow text-white" 
+                      ? "bg-blue-100 text-blue-700" 
                       : "hover:bg-[hsl(214,84%,56%)] hover:bg-opacity-10 hover:text-foreground"
                   )}
                 >

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -1225,7 +1225,7 @@ const Schedule = () => {
         <div className="px-6 py-4">
           <div className="mb-3">
             <div>
-              <h1 className="text-2xl font-bold text-education-navy">SCHEDULE</h1>
+              <h1 className="text-2xl font-bold text-education-navy">SESSIONS</h1>
             </div>
           </div>
           


### PR DESCRIPTION
- Change page title from 'SCHEDULE' to 'SESSIONS' in Sessions page
- Replace gradient background with simple light blue (bg-blue-100 text-blue-700) for active sidebar items
- Apply changes to both desktop and mobile navigation
- Remove flashy gradient and shadow effects for minimalist design