### PR TITLE
Change application font theme to Poppins

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@
     <title>AMSUIP</title>
     <link rel="icon" href="/favicon.png" type="image/png">
     <link rel="shortcut icon" href="/favicon.png" type="image/png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
     
   </head>
 

--- a/src/index.css
+++ b/src/index.css
@@ -127,7 +127,7 @@ All colors MUST be HSL.
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans;
   }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,6 +17,9 @@ module.exports = {
 			}
 		},
 		extend: {
+			fontFamily: {
+				sans: ['Poppins', 'ui-sans-serif', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Arial', 'Noto Sans', 'sans-serif'],
+			},
 			colors: {
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',


### PR DESCRIPTION
- Add Google Fonts Poppins link to index.html with all weights and styles
- Configure Poppins as the default sans-serif font in Tailwind config
- Apply font-sans class to body element in CSS
- Include fallback fonts for better compatibility