### PR TITLE
Update table font styling to match headers without bold

### DIFF
--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -311,7 +311,7 @@ const Accounts = () => {
                       <th scope="col" className="px-3 py-2 text-left font-medium">Actions</th>
                     </tr>
                   </thead>
-                  <tbody className="bg-white divide-y divide-gray-200 text-sm">
+                  <tbody className="bg-white divide-y divide-gray-200 text-xs text-gray-500">
                     {isLoading ? (
                       <tr className="h-8">
                         <td colSpan={6} className="px-3 py-1 text-center">
@@ -331,22 +331,22 @@ const Accounts = () => {
                       filteredProfiles.map((profile) => (
                         <tr key={profile.id} className="hover:bg-gray-50 h-8">
                           <td className="px-3 py-1 whitespace-nowrap">
-                            <div className="text-sm font-medium text-gray-900">
+                            <div className="font-medium">
                               {profile.first_name && profile.last_name 
                                 ? `${profile.first_name} ${profile.last_name}`
                                 : profile.email.split('@')[0]}
                             </div>
                           </td>
-                          <td className="px-3 py-1 whitespace-nowrap text-gray-500 text-sm">
+                          <td className="px-3 py-1 whitespace-nowrap">
                             {profile.email}
                           </td>
-                          <td className="px-3 py-1 whitespace-nowrap text-gray-500 text-sm">
+                          <td className="px-3 py-1 whitespace-nowrap">
                             <RoleDisplay role={profile.role} />
                           </td>
-                          <td className="px-3 py-1 whitespace-nowrap text-gray-500 text-sm">
+                          <td className="px-3 py-1 whitespace-nowrap">
                             <StatusDisplay status={profile.status} />
                           </td>
-                          <td className="px-3 py-1 whitespace-nowrap text-gray-500 text-sm">
+                          <td className="px-3 py-1 whitespace-nowrap">
                             {format(new Date(profile.created_at), 'MMM d, yyyy')}
                           </td>
                           <td className="px-3 py-1 whitespace-nowrap text-right">

--- a/src/pages/AllowedTerms.tsx
+++ b/src/pages/AllowedTerms.tsx
@@ -242,7 +242,7 @@ const AllowedTermsContent = () => {
                 <th scope="col" className="px-3 py-2 text-left font-medium"></th>
               </tr>
             </thead>
-            <tbody className="bg-white divide-y divide-gray-200 text-sm">
+            <tbody className="bg-white divide-y divide-gray-200 text-xs text-gray-500">
               {loading ? (
                 <tr className="h-8">
                   <td colSpan={3} className="px-3 py-1 text-center">
@@ -264,9 +264,9 @@ const AllowedTermsContent = () => {
                 paginatedTerms.map((term) => (
                   <tr key={term.id} className="hover:bg-gray-50 h-8">
                     <td className="px-3 py-1 whitespace-nowrap">
-                      <div className="text-sm font-medium text-gray-900">{term.academic_year}</div>
+                      <div className="font-medium">{term.academic_year}</div>
                     </td>
-                    <td className="px-3 py-1 whitespace-nowrap text-gray-500 text-sm">
+                    <td className="px-3 py-1 whitespace-nowrap">
                       {term.semester}
                     </td>
                     <td className="px-3 py-1 whitespace-nowrap text-right">

--- a/src/pages/ExcuseApplication.tsx
+++ b/src/pages/ExcuseApplication.tsx
@@ -565,7 +565,7 @@ const ExcuseApplicationContent = () => {
                 <th scope="col" className="px-3 py-2 text-left font-medium"></th>
               </tr>
             </thead>
-            <tbody className="bg-white divide-y divide-gray-200 text-sm">
+            <tbody className="bg-white divide-y divide-gray-200 text-xs text-gray-500">
               {loading ? (
                 <tr className="h-8">
                   <td colSpan={6} className="px-3 py-1 text-center">
@@ -587,14 +587,14 @@ const ExcuseApplicationContent = () => {
                 filteredExcuses.map((excuse) => (
                   <tr key={excuse.id} className="hover:bg-gray-50 h-8">
                     <td className="px-3 py-1 whitespace-nowrap">
-                      <div className="text-sm font-medium text-gray-900">
+                      <div className="font-medium">
                         {excuse.students?.firstname} {excuse.students?.surname}
                       </div>
                     </td>
-                    <td className="px-3 py-1 whitespace-nowrap text-gray-500 text-sm">
+                    <td className="px-3 py-1 whitespace-nowrap">
                       {excuse.students?.student_id}
                     </td>
-                    <td className="px-3 py-1 whitespace-nowrap text-gray-500 text-sm">
+                    <td className="px-3 py-1 whitespace-nowrap">
                       {format(new Date(excuse.absence_date), 'MMM d, yyyy')}
                     </td>
                     <td className="px-3 py-1 whitespace-nowrap">
@@ -616,7 +616,7 @@ const ExcuseApplicationContent = () => {
                         <span className="text-sm text-gray-400">No attachment</span>
                       )}
                     </td>
-                    <td className="px-3 py-1 whitespace-nowrap text-gray-500 text-sm">
+                    <td className="px-3 py-1 whitespace-nowrap">
                       {getStatusDisplay(excuse.status)}
                     </td>
                     <td className="px-3 py-1 whitespace-nowrap text-right">

--- a/src/pages/Students.tsx
+++ b/src/pages/Students.tsx
@@ -471,7 +471,7 @@ const Students = () => {
                   <th scope="col" className="px-3 py-2 text-left font-medium">Year & Section</th>
                 </tr>
               </thead>
-              <tbody className="bg-white divide-y divide-gray-200 text-sm">
+              <tbody className="bg-white divide-y divide-gray-200 text-xs text-gray-500">
                 {loading ? (
                 <tr className="h-8">
                   <td colSpan={4} className="px-3 py-1 text-center">
@@ -504,18 +504,18 @@ const Students = () => {
                     <tr key={student.id} className="hover:bg-gray-50 h-8">
                       <td className="px-3 py-1 whitespace-nowrap">
                         <div>
-                          <div className="text-sm font-medium text-gray-900">
+                          <div className="font-medium">
                             {student.surname}, {student.firstname}{student.middlename ? ' ' + student.middlename.charAt(0) + '.' : ''}
                           </div>
                         </div>
                       </td>
-                      <td className="px-3 py-1 whitespace-nowrap text-gray-500 text-sm">
+                      <td className="px-3 py-1 whitespace-nowrap">
                         {student.student_id}
                       </td>
-                      <td className="px-3 py-1 whitespace-nowrap text-gray-500 text-sm">
+                      <td className="px-3 py-1 whitespace-nowrap">
                         <span className="truncate max-w-[120px] inline-block">{student.program}</span>
                       </td>
-                      <td className="px-3 py-1 whitespace-nowrap text-gray-500 text-sm">
+                      <td className="px-3 py-1 whitespace-nowrap">
                         <div className="flex items-center gap-1">
                           <span>{student.year}</span>
                           <span className="text-gray-300">•</span>


### PR DESCRIPTION
- Change table body fonts from text-sm to text-xs text-gray-500 to match header style
- Remove font-medium from body cells while keeping it in headers
- Remove redundant text-sm and text-gray-500 classes from individual cells
- Apply changes to all table pages: Students, Accounts, Excuse Applications, Allowed Terms
- Headers remain: text-xs text-gray-500 font-medium (bold)
- Body cells now: text-xs text-gray-500 (same style as headers but not bold)