### PR TITLE
Update table fonts, sidebar styling, and header layout

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,7 +12,6 @@ import {
   GraduationCap, 
   User, 
   LogOut, 
-  CalendarDays,
   Menu
 } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
@@ -245,11 +244,16 @@ const Header = ({ isMobile = false }: HeaderProps) => {
           {/* Academic Year and Semester */}
           {academicYear && (
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <CalendarDays className="w-4 h-4" />
+              <span>Current A.Y.:</span>
               <span>{academicYear.year}</span>
               <span>•</span>
               <span>{academicYear.semester}</span>
             </div>
+          )}
+
+          {/* Vertical Separator */}
+          {academicYear && (
+            <div className="h-4 w-px bg-gray-300"></div>
           )}
 
           {/* Panel Label */}

--- a/src/components/ui/navigation.tsx
+++ b/src/components/ui/navigation.tsx
@@ -340,12 +340,12 @@ const DesktopNavigation = () => {
                   // Unified dimensions in both states to prevent distortion
                   "h-8 justify-start px-2 w-full rounded-sm overflow-hidden",
                   isActive 
-                    ? "bg-gray-200 text-black"
-                    : "hover:bg-gray-100 hover:text-foreground"
+                    ? "bg-gray-200 text-black font-bold"
+                    : "hover:bg-gray-100 hover:text-foreground font-normal"
                 )}
               >
                 <Icon className="flex-shrink-0 w-4 h-4" />
-                <span className="ml-2 font-medium whitespace-nowrap min-w-0 flex-1 text-sm">
+                <span className="ml-2 whitespace-nowrap min-w-0 flex-1 text-sm">
                   {item.label}
                 </span>
               </div>
@@ -553,8 +553,8 @@ const MobileDrawer = ({ isOpen, onClose }: { isOpen: boolean; onClose: () => voi
                   className={cn(
                     "w-full justify-start gap-3 h-10 text-sm transition-all duration-200 group relative overflow-hidden",
                     isActive 
-                      ? "bg-gray-200 text-black" 
-                      : "hover:bg-gray-100 hover:text-foreground"
+                      ? "bg-gray-200 text-black font-bold" 
+                      : "hover:bg-gray-100 hover:text-foreground font-normal"
                   )}
                 >
                   <Icon className="w-4.5 h-4.5" />

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -302,16 +302,16 @@ const Accounts = () => {
             <div className="border-t border-b border-gray-200 overflow-hidden">
                 <table className="min-w-full divide-y divide-gray-200">
                   <thead className="bg-gray-50">
-                    <tr className="text-xs text-gray-500 h-8">
-                      <th scope="col" className="px-3 py-2 text-left font-medium">User</th>
-                      <th scope="col" className="px-3 py-2 text-left font-medium">Email</th>
-                      <th scope="col" className="px-3 py-2 text-left font-medium">Role</th>
-                      <th scope="col" className="px-3 py-2 text-left font-medium">Status</th>
-                      <th scope="col" className="px-3 py-2 text-left font-medium">Created</th>
-                      <th scope="col" className="px-3 py-2 text-left font-medium">Actions</th>
+                    <tr className="text-xs text-black h-8">
+                      <th scope="col" className="px-3 py-2 text-left font-bold">User</th>
+                      <th scope="col" className="px-3 py-2 text-left font-bold">Email</th>
+                      <th scope="col" className="px-3 py-2 text-left font-bold">Role</th>
+                      <th scope="col" className="px-3 py-2 text-left font-bold">Status</th>
+                      <th scope="col" className="px-3 py-2 text-left font-bold">Created</th>
+                      <th scope="col" className="px-3 py-2 text-left font-bold">Actions</th>
                     </tr>
                   </thead>
-                  <tbody className="bg-white divide-y divide-gray-200 text-xs text-gray-500">
+                  <tbody className="bg-white divide-y divide-gray-200 text-xs text-black">
                     {isLoading ? (
                       <tr className="h-8">
                         <td colSpan={6} className="px-3 py-1 text-center">

--- a/src/pages/AllowedTerms.tsx
+++ b/src/pages/AllowedTerms.tsx
@@ -236,13 +236,13 @@ const AllowedTermsContent = () => {
         <div className="border-t border-b border-gray-200 overflow-hidden">
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
-              <tr className="text-xs text-gray-500 h-8">
-                <th scope="col" className="px-3 py-2 text-left font-medium">Academic Year</th>
-                <th scope="col" className="px-3 py-2 text-left font-medium">Semester</th>
-                <th scope="col" className="px-3 py-2 text-left font-medium"></th>
+              <tr className="text-xs text-black h-8">
+                <th scope="col" className="px-3 py-2 text-left font-bold">Academic Year</th>
+                <th scope="col" className="px-3 py-2 text-left font-bold">Semester</th>
+                <th scope="col" className="px-3 py-2 text-left font-bold"></th>
               </tr>
             </thead>
-            <tbody className="bg-white divide-y divide-gray-200 text-xs text-gray-500">
+            <tbody className="bg-white divide-y divide-gray-200 text-xs text-black">
               {loading ? (
                 <tr className="h-8">
                   <td colSpan={3} className="px-3 py-1 text-center">

--- a/src/pages/ExcuseApplication.tsx
+++ b/src/pages/ExcuseApplication.tsx
@@ -556,16 +556,16 @@ const ExcuseApplicationContent = () => {
         <div className="border-t border-b border-gray-200 overflow-hidden">
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
-              <tr className="text-xs text-gray-500 h-8">
-                <th scope="col" className="px-3 py-2 text-left font-medium">Name</th>
-                <th scope="col" className="px-3 py-2 text-left font-medium">ID</th>
-                <th scope="col" className="px-3 py-2 text-left font-medium">Date of Session</th>
-                <th scope="col" className="px-3 py-2 text-left font-medium">Documentation</th>
-                <th scope="col" className="px-3 py-2 text-left font-medium">Status</th>
-                <th scope="col" className="px-3 py-2 text-left font-medium"></th>
+              <tr className="text-xs text-black h-8">
+                <th scope="col" className="px-3 py-2 text-left font-bold">Name</th>
+                <th scope="col" className="px-3 py-2 text-left font-bold">ID</th>
+                <th scope="col" className="px-3 py-2 text-left font-bold">Date of Session</th>
+                <th scope="col" className="px-3 py-2 text-left font-bold">Documentation</th>
+                <th scope="col" className="px-3 py-2 text-left font-bold">Status</th>
+                <th scope="col" className="px-3 py-2 text-left font-bold"></th>
               </tr>
             </thead>
-            <tbody className="bg-white divide-y divide-gray-200 text-xs text-gray-500">
+            <tbody className="bg-white divide-y divide-gray-200 text-xs text-black">
               {loading ? (
                 <tr className="h-8">
                   <td colSpan={6} className="px-3 py-1 text-center">

--- a/src/pages/Students.tsx
+++ b/src/pages/Students.tsx
@@ -464,14 +464,14 @@ const Students = () => {
           <div className="border-t border-b border-gray-200 overflow-hidden">
           <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50">
-                <tr className="text-xs text-gray-500 h-8">
-                  <th scope="col" className="px-3 py-2 text-left font-medium">Student</th>
-                  <th scope="col" className="px-3 py-2 text-left font-medium">ID</th>
-                  <th scope="col" className="px-3 py-2 text-left font-medium">Program</th>
-                  <th scope="col" className="px-3 py-2 text-left font-medium">Year & Section</th>
+                <tr className="text-xs text-black h-8">
+                  <th scope="col" className="px-3 py-2 text-left font-bold">Student</th>
+                  <th scope="col" className="px-3 py-2 text-left font-bold">ID</th>
+                  <th scope="col" className="px-3 py-2 text-left font-bold">Program</th>
+                  <th scope="col" className="px-3 py-2 text-left font-bold">Year & Section</th>
                 </tr>
               </thead>
-              <tbody className="bg-white divide-y divide-gray-200 text-xs text-gray-500">
+              <tbody className="bg-white divide-y divide-gray-200 text-xs text-black">
                 {loading ? (
                 <tr className="h-8">
                   <td colSpan={4} className="px-3 py-1 text-center">


### PR DESCRIPTION
Table Fonts:
- Make table header fonts black and bold (text-black font-bold)
- Make table body fonts black but not bold (text-black)
- Apply to all table pages: Students, Accounts, Excuse Applications, Allowed Terms

Sidebar Styling:
- Make sidebar icons and labels normal/thin (font-normal)
- Active items become bold (font-bold)
- Apply to both desktop and mobile navigation
- Remove redundant font-medium from span elements

Header Layout:
- Remove calendar icon from header
- Add 'Current A.Y.:' label before academic year/semester
- Add vertical separator line between academic year/semester and account panel
- Remove unused CalendarDays import