### PR TITLE
Reduce font weights for table headers and sidebar active state

### DIFF
--- a/src/components/ui/navigation.tsx
+++ b/src/components/ui/navigation.tsx
@@ -340,7 +340,7 @@ const DesktopNavigation = () => {
                   // Unified dimensions in both states to prevent distortion
                   "h-8 justify-start px-2 w-full rounded-sm overflow-hidden",
                   isActive 
-                    ? "bg-gray-200 text-black font-bold"
+                    ? "bg-gray-200 text-black font-semibold"
                     : "hover:bg-gray-100 hover:text-foreground font-normal"
                 )}
               >
@@ -553,7 +553,7 @@ const MobileDrawer = ({ isOpen, onClose }: { isOpen: boolean; onClose: () => voi
                   className={cn(
                     "w-full justify-start gap-3 h-10 text-sm transition-all duration-200 group relative overflow-hidden",
                     isActive 
-                      ? "bg-gray-200 text-black font-bold" 
+                      ? "bg-gray-200 text-black font-semibold" 
                       : "hover:bg-gray-100 hover:text-foreground font-normal"
                   )}
                 >

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -303,12 +303,12 @@ const Accounts = () => {
                 <table className="min-w-full divide-y divide-gray-200">
                   <thead className="bg-gray-50">
                     <tr className="text-xs text-black h-8">
-                      <th scope="col" className="px-3 py-2 text-left font-bold">User</th>
-                      <th scope="col" className="px-3 py-2 text-left font-bold">Email</th>
-                      <th scope="col" className="px-3 py-2 text-left font-bold">Role</th>
-                      <th scope="col" className="px-3 py-2 text-left font-bold">Status</th>
-                      <th scope="col" className="px-3 py-2 text-left font-bold">Created</th>
-                      <th scope="col" className="px-3 py-2 text-left font-bold">Actions</th>
+                      <th scope="col" className="px-3 py-2 text-left font-semibold uppercase">User</th>
+                      <th scope="col" className="px-3 py-2 text-left font-semibold uppercase">Email</th>
+                      <th scope="col" className="px-3 py-2 text-left font-semibold uppercase">Role</th>
+                      <th scope="col" className="px-3 py-2 text-left font-semibold uppercase">Status</th>
+                      <th scope="col" className="px-3 py-2 text-left font-semibold uppercase">Created</th>
+                      <th scope="col" className="px-3 py-2 text-left font-semibold uppercase">Actions</th>
                     </tr>
                   </thead>
                   <tbody className="bg-white divide-y divide-gray-200 text-xs text-black">

--- a/src/pages/AllowedTerms.tsx
+++ b/src/pages/AllowedTerms.tsx
@@ -237,9 +237,9 @@ const AllowedTermsContent = () => {
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
               <tr className="text-xs text-black h-8">
-                <th scope="col" className="px-3 py-2 text-left font-bold">Academic Year</th>
-                <th scope="col" className="px-3 py-2 text-left font-bold">Semester</th>
-                <th scope="col" className="px-3 py-2 text-left font-bold"></th>
+                <th scope="col" className="px-3 py-2 text-left font-semibold uppercase">Academic Year</th>
+                <th scope="col" className="px-3 py-2 text-left font-semibold uppercase">Semester</th>
+                <th scope="col" className="px-3 py-2 text-left font-semibold uppercase"></th>
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200 text-xs text-black">

--- a/src/pages/ExcuseApplication.tsx
+++ b/src/pages/ExcuseApplication.tsx
@@ -557,12 +557,12 @@ const ExcuseApplicationContent = () => {
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
               <tr className="text-xs text-black h-8">
-                <th scope="col" className="px-3 py-2 text-left font-bold">Name</th>
-                <th scope="col" className="px-3 py-2 text-left font-bold">ID</th>
-                <th scope="col" className="px-3 py-2 text-left font-bold">Date of Session</th>
-                <th scope="col" className="px-3 py-2 text-left font-bold">Documentation</th>
-                <th scope="col" className="px-3 py-2 text-left font-bold">Status</th>
-                <th scope="col" className="px-3 py-2 text-left font-bold"></th>
+                <th scope="col" className="px-3 py-2 text-left font-semibold uppercase">Name</th>
+                <th scope="col" className="px-3 py-2 text-left font-semibold uppercase">ID</th>
+                <th scope="col" className="px-3 py-2 text-left font-semibold uppercase">Date of Session</th>
+                <th scope="col" className="px-3 py-2 text-left font-semibold uppercase">Documentation</th>
+                <th scope="col" className="px-3 py-2 text-left font-semibold uppercase">Status</th>
+                <th scope="col" className="px-3 py-2 text-left font-semibold uppercase"></th>
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200 text-xs text-black">

--- a/src/pages/Students.tsx
+++ b/src/pages/Students.tsx
@@ -465,10 +465,10 @@ const Students = () => {
           <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50">
                 <tr className="text-xs text-black h-8">
-                  <th scope="col" className="px-3 py-2 text-left font-bold">Student</th>
-                  <th scope="col" className="px-3 py-2 text-left font-bold">ID</th>
-                  <th scope="col" className="px-3 py-2 text-left font-bold">Program</th>
-                  <th scope="col" className="px-3 py-2 text-left font-bold">Year & Section</th>
+                  <th scope="col" className="px-3 py-2 text-left font-semibold uppercase">Student</th>
+                  <th scope="col" className="px-3 py-2 text-left font-semibold uppercase">ID</th>
+                  <th scope="col" className="px-3 py-2 text-left font-semibold uppercase">Program</th>
+                  <th scope="col" className="px-3 py-2 text-left font-semibold uppercase">Year & Section</th>
                 </tr>
               </thead>
               <tbody className="bg-white divide-y divide-gray-200 text-xs text-black">


### PR DESCRIPTION
Table Headers:
- Make all table headers uppercase (uppercase class)
- Reduce weight from font-bold to font-semibold
- Apply to all table pages: Students, Accounts, Excuse Applications, Allowed Terms

Sidebar Active State:
- Reduce weight from font-bold to font-semibold for active items
- Apply to both desktop and mobile navigation
- Maintains visual hierarchy while being less heavy