### PR TITLE
Fix remaining green dropdown hovers and remove all card hover effects

### DIFF
--- a/src/components/AttendanceForm.tsx
+++ b/src/components/AttendanceForm.tsx
@@ -585,7 +585,7 @@ const AttendanceForm = ({ onSuccess, onSubmit, initialData }: AttendanceFormProp
               .map((option) => (
               <div 
                 key={option.type} 
-                className={`group relative rounded-lg p-0.5 ${option.bg} ${option.hoverBg} transition-all duration-200 hover:scale-105 hover:shadow-md w-full`}
+                className={`group relative rounded-lg p-0.5 ${option.bg} ${option.hoverBg} transition-all duration-200 hover:scale-105 w-full`}
               >
                 <div 
                   className={`p-4 rounded-lg cursor-pointer transition-all duration-200 h-full ${

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -384,7 +384,7 @@ const Dashboard = () => {
       
       {/* Minimalist Stats Cards */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5">
-        <Card className="bg-white border border-gray-200 shadow-sm hover:shadow-md transition-all duration-200">
+        <Card className="bg-white border border-gray-200 shadow-sm">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 px-6 pt-6">
             <CardTitle className="text-sm font-medium text-gray-700">Total Students</CardTitle>
             <div className="p-2 bg-blue-100 rounded-lg">
@@ -402,7 +402,7 @@ const Dashboard = () => {
           </CardContent>
         </Card>
         
-        <Card className="bg-white border border-gray-200 shadow-sm hover:shadow-md transition-all duration-200">
+        <Card className="bg-white border border-gray-200 shadow-sm">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 px-6 pt-6">
             <CardTitle className="text-sm font-medium text-gray-700">Today's Attendance</CardTitle>
             <div className="p-2 bg-purple-100 rounded-lg">
@@ -424,7 +424,7 @@ const Dashboard = () => {
           </CardContent>
         </Card>
         
-        <Card className="bg-white border border-gray-200 shadow-sm hover:shadow-md transition-all duration-200">
+        <Card className="bg-white border border-gray-200 shadow-sm">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 px-6 pt-6">
             <CardTitle className="text-sm font-medium text-gray-700">Attendance Rate</CardTitle>
             <div className="p-2 bg-green-100 rounded-lg">
@@ -444,7 +444,7 @@ const Dashboard = () => {
           </CardContent>
         </Card>
         
-        <Card className="bg-white border border-gray-200 shadow-sm hover:shadow-md transition-all duration-200">
+        <Card className="bg-white border border-gray-200 shadow-sm">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 px-6 pt-6">
             <CardTitle className="text-sm font-medium text-gray-700">Today's Sessions</CardTitle>
             <div className="p-2 bg-orange-100 rounded-lg">
@@ -462,7 +462,7 @@ const Dashboard = () => {
           </CardContent>
         </Card>
         
-        <Card className="bg-white border border-gray-200 shadow-sm hover:shadow-md transition-all duration-200">
+        <Card className="bg-white border border-gray-200 shadow-sm">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 px-6 pt-6">
             <CardTitle className="text-sm font-medium text-gray-700">Academic Year</CardTitle>
             <div className="p-2 bg-indigo-100 rounded-lg">

--- a/src/components/StudentTrainingCard.tsx
+++ b/src/components/StudentTrainingCard.tsx
@@ -66,7 +66,7 @@ const StudentTrainingCard: React.FC<StudentTrainingCardProps> = ({
 
   return (
     <Card 
-      className="relative cursor-pointer hover:shadow-md transition-shadow h-10 group"
+      className="relative cursor-pointer h-10 group"
       onClick={handleCardClick}
     >
       <CardContent className="py-0 px-2 pr-1 h-full flex flex-col justify-center">

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm hover:shadow-md transition-shadow duration-200",
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
       className
     )}
     {...props}

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -25,7 +25,7 @@ const ContextMenuSubTrigger = React.forwardRef<
   <ContextMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-gray-200 focus:text-gray-900 data-[state=open]:bg-gray-200 data-[state=open]:text-gray-900",
       inset && "pl-8",
       className
     )}
@@ -78,7 +78,7 @@ const ContextMenuItem = React.forwardRef<
   <ContextMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-gray-200 focus:text-gray-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className
     )}

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -36,7 +36,7 @@ const MenubarTrigger = React.forwardRef<
   <MenubarPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-3 py-1.5 text-sm font-medium outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      "flex cursor-default select-none items-center rounded-sm px-3 py-1.5 text-sm font-medium outline-none focus:bg-gray-200 focus:text-gray-900 data-[state=open]:bg-gray-200 data-[state=open]:text-gray-900",
       className
     )}
     {...props}
@@ -53,7 +53,7 @@ const MenubarSubTrigger = React.forwardRef<
   <MenubarPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-gray-200 focus:text-gray-900 data-[state=open]:bg-gray-200 data-[state=open]:text-gray-900",
       inset && "pl-8",
       className
     )}
@@ -114,7 +114,7 @@ const MenubarItem = React.forwardRef<
   <MenubarPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-gray-200 focus:text-gray-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className
     )}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -116,7 +116,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-gray-200 focus:text-gray-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -172,7 +172,7 @@ const Reports = () => {
         {/* Reports List */}
         <div className="space-y-3">
           {mockReports.map((report) => (
-            <Card key={report.id} className="bg-gradient-card border-0 shadow-card hover:shadow-elegant transition-all duration-300">
+            <Card key={report.id} className="bg-gradient-card border-0 shadow-card">
               <CardContent className="p-4">
                 <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
                   <div className="flex items-center gap-3">

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -1286,7 +1286,7 @@ const Schedule = () => {
                 </div>
               ) : paginatedSessions.length > 0 ? (
                 [...paginatedSessions].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()).map((session) => (
-                <Card key={session.id} className="bg-gradient-card border-0 shadow-card hover:shadow-elegant transition-all duration-300">
+                <Card key={session.id} className="bg-gradient-card border-0 shadow-card">
                   <CardContent className="p-3">
                     <div className="flex items-center justify-between">
                       <div className="flex items-start gap-3">

--- a/src/pages/SignatureAI.tsx
+++ b/src/pages/SignatureAI.tsx
@@ -1289,7 +1289,7 @@ const SignatureAI = () => {
                     Object.entries(dateGroupedModels).map(([date, models]) => (
                       <div key={date} className="group">
                         <Card 
-                          className="h-10 cursor-pointer hover:shadow-md transition-shadow"
+                          className="h-10 cursor-pointer"
                           onClick={() => setSelectedDate(date)}
                         >
                           <CardContent className="py-0 px-2 pr-1 h-full flex items-center">

--- a/src/pages/TakeAttendance.tsx
+++ b/src/pages/TakeAttendance.tsx
@@ -382,7 +382,7 @@ interface SessionCardProps {
 
 const SessionCard: React.FC<SessionCardProps> = ({ session, onStartAttendance }) => {
   return (
-    <Card className="relative overflow-hidden shadow-sm hover:shadow-md transition-shadow">
+    <Card className="relative overflow-hidden shadow-sm">
       <div className="absolute top-2 right-2">
         {session.type === 'class' && (
           <Badge className="bg-primary/10 text-primary border-primary/20 text-xs">Class</Badge>


### PR DESCRIPTION
- Fixed SelectItem, ContextMenuItem, and MenubarItem green hover effects
- Changed all focus:bg-accent to focus:bg-gray-200 for consistency
- Removed hover shadow effects from all cards globally
- Updated Card component to remove default hover:shadow-md
- Removed card hover effects from Dashboard, Reports, Sessions, SignatureAI, TakeAttendance
- Removed hover shadow from StudentTrainingCard and AttendanceForm
- All dropdown items now consistently use gray hover instead of green